### PR TITLE
Use SVG instead of raster image for better quality of rotated text

### DIFF
--- a/birt.controls.lib/META-INF/MANIFEST.MF
+++ b/birt.controls.lib/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: birt.controls.lib;singleton:=true
-Bundle-Version: 2.5.2.2
+Bundle-Version: 2.5.2.3
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor

--- a/birt.controls.lib/plugin.xml
+++ b/birt.controls.lib/plugin.xml
@@ -167,7 +167,7 @@
    <extension
          point="org.eclipse.birt.report.engine.reportitemPresentation">
       <reportItem
-            class="blackboard.birt.extensions.rotatedtext.RotatedTextPresentationImpl"
+            class="blackboard.birt.extensions.rotatedtext.RotatedTextSVGPresentationImpl"
             name="RotatedText">
       </reportItem>
    </extension>

--- a/birt.controls.lib/readme.txt
+++ b/birt.controls.lib/readme.txt
@@ -5,3 +5,6 @@ Initial
 
 2.5.2.1
 Fix issue 5 where IllegalArgumentException is generated when null data provided to RotatedTextControl
+
+2.5.2.3
+Use SVG instead of raster image for better quality of rotated text in PDF

--- a/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/RotatedTextPresentationImpl.java
+++ b/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/RotatedTextPresentationImpl.java
@@ -14,19 +14,12 @@
  */
 package blackboard.birt.extensions.rotatedtext;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-
-import javax.imageio.ImageIO;
-import javax.imageio.stream.ImageOutputStream;
-
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.report.engine.extension.IBaseResultSet;
 import org.eclipse.birt.report.engine.extension.ICubeResultSet;
 import org.eclipse.birt.report.engine.extension.IQueryResultSet;
 import org.eclipse.birt.report.engine.extension.ReportItemPresentationBase;
+import org.eclipse.birt.report.engine.extension.Size;
 import org.eclipse.birt.report.model.api.ExtendedItemHandle;
 import org.eclipse.birt.report.model.api.extension.ExtendedElementException;
 
@@ -38,8 +31,10 @@ import org.eclipse.birt.report.model.api.extension.ExtendedElementException;
  * @author Steve Schafer / Innovent Solutions
  */
 public class RotatedTextPresentationImpl extends ReportItemPresentationBase {
-	private RotatedTextItem textItem;
-	private static int index = 0;
+	protected RotatedTextItem textItem;
+	protected static int index = 0;
+	
+	protected Size size;
 
 	@Override
 	public void setModelObject(final ExtendedItemHandle modelHandle) {
@@ -54,6 +49,11 @@ public class RotatedTextPresentationImpl extends ReportItemPresentationBase {
 	public int getOutputType() {
 		return OUTPUT_AS_IMAGE_WITH_MAP;
 	}
+	
+	@Override
+	public Size getSize() {
+	  return size;
+	}
 
 	@Override
 	public Object onRowSets(final IBaseResultSet[] results)
@@ -67,33 +67,17 @@ public class RotatedTextPresentationImpl extends ReportItemPresentationBase {
 			text = " ";
 		final String url = this.evaluate(data.linkURL, results);
 
-		final BufferedImage rotatedImage = SwingGraphicsUtil
-				.createRotatedTextImage(text, data, this.dpi, 1, "in");
-		ByteArrayInputStream bis = null;
-
-		try {
-			ImageIO.setUseCache(false);
-			final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			final ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
-			// System.out.println(rotatedImage);
-			// System.out.println(ios);
-			if (rotatedImage != null)
-				ImageIO.write(rotatedImage, "png", ios); //$NON-NLS-1$
-			ios.flush();
-			ios.close();
-			bis = new ByteArrayInputStream(baos.toByteArray());
-		} catch (final IOException e) {
-			e.printStackTrace();
-		}
-
+		TextImage image = SwingGraphicsUtil.createRotatedTextImage(text, data, this.dpi, 1, "in", getImageMIMEType());
+		size = new Size();
+		size.setWidth(image.getWidth());
+		size.setHeight(image.getHeight());
+		size.setUnit("px");
 		return new Object[] {
-				bis,
-				this.createImageMap(url, text, rotatedImage == null ? 0
-						: rotatedImage.getWidth(), rotatedImage == null ? 0
-						: rotatedImage.getHeight()) };
+		    image.getImage(),
+				this.createImageMap(url, text, image.getWidth(), image.getHeight()) };
 	}
 
-	private String evaluate(final String expression,
+	protected String evaluate(final String expression,
 			final IBaseResultSet[] results) throws BirtException {
 		String text = null;
 		if (expression == null || "null".equalsIgnoreCase(expression))
@@ -121,7 +105,7 @@ public class RotatedTextPresentationImpl extends ReportItemPresentationBase {
 		return text;
 	}
 
-	private String createImageMap(final String url, final String text,
+	protected String createImageMap(final String url, final String text,
 			final int width, final int height) {
 		final StringBuilder sb = new StringBuilder();
 

--- a/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/RotatedTextSVGPresentationImpl.java
+++ b/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/RotatedTextSVGPresentationImpl.java
@@ -1,0 +1,14 @@
+
+package blackboard.birt.extensions.rotatedtext;
+
+/**
+ * SVG presentation.
+ */
+public class RotatedTextSVGPresentationImpl extends RotatedTextPresentationImpl {
+
+  @Override
+  public String getImageMIMEType() {
+    return "image/svg+xml";
+  }
+  
+}

--- a/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextBufferedImage.java
+++ b/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextBufferedImage.java
@@ -1,0 +1,74 @@
+
+package blackboard.birt.extensions.rotatedtext;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.io.InputStream;
+
+import blackboard.birt.extensions.rotatedtext.SwingGraphicsUtil.LineInfo;
+
+/**
+ * Text drawn on a raster image.
+ */
+public class TextBufferedImage implements TextImage {
+  LineInfo[] lines;
+  double angle;
+  int width;
+  int height;
+  double tx;
+  double ty;
+  Color color;
+  
+  public TextBufferedImage(final LineInfo[] lines,
+    final double angle, final int width, final int height,
+    final double tx, final double ty, final Color color) {
+    this.lines = lines;
+    this.angle = angle;
+    this.width = width;
+    this.height = height;
+    this.tx = tx;
+    this.ty = ty;
+    this.color = color;
+  }
+
+  public int getWidth() {
+    return this.width;
+  }
+
+  public int getHeight() {
+    return this.height;
+  }
+  
+  protected void draw(Graphics2D g2d) {
+    g2d.setColor(Color.black);
+    g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+    g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+    final AffineTransform at = AffineTransform.getRotateInstance(angle);
+    at.translate(tx, ty);
+    g2d.setTransform(at);
+    g2d.setColor(color);
+
+    float y = 0;
+    for (final LineInfo lineInfo : lines) {
+      if (lineInfo.textLayout != null)
+        g2d.setFont(lineInfo.font);
+      lineInfo.textLayout.draw(g2d, 0,
+        y + (int)Math.ceil(lineInfo.textLayout.getLeading() + lineInfo.textLayout.getAscent()));
+      y += lineInfo.bounds.getHeight();
+    }
+  }
+
+  public InputStream getImage() {
+    final BufferedImage bufferedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+
+    final Graphics2D g2d = (Graphics2D)bufferedImage.getGraphics();
+    draw(g2d);
+    g2d.dispose();
+    return SwingGraphicsUtil.toStream(bufferedImage);
+  }
+
+}

--- a/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextImage.java
+++ b/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextImage.java
@@ -1,0 +1,17 @@
+
+package blackboard.birt.extensions.rotatedtext;
+
+import java.io.InputStream;
+
+/**
+ * Text as an image.
+ */
+public interface TextImage {
+  
+  int getWidth();
+  
+  int getHeight();
+  
+  InputStream getImage();
+
+}

--- a/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextImageFactory.java
+++ b/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextImageFactory.java
@@ -1,0 +1,33 @@
+
+package blackboard.birt.extensions.rotatedtext;
+
+import java.awt.Color;
+
+import blackboard.birt.extensions.rotatedtext.SwingGraphicsUtil.LineInfo;
+
+/**
+ * Factory for creating an image from the text info & image type.
+ */
+class TextImageFactory {
+  
+  static TextImageFactory instance = new TextImageFactory();
+  
+  private TextImageFactory() {
+    
+  }
+  
+  static TextImageFactory getInstance() {
+    return instance;
+  }
+  
+  TextImage createTextImage(String type, LineInfo[] lines,
+     double angle,  int width,  int height,
+     double tx,  double ty, Color color) {
+    if ("image/svg+xml".equals(type)) {
+      return new TextSVGImage(lines, angle, width, height, tx, ty, color);
+    } else {
+      return new TextBufferedImage(lines, angle, width, height, tx, ty, color);
+    }
+  }
+
+}

--- a/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextSVGImage.java
+++ b/birt.controls.lib/src/blackboard/birt/extensions/rotatedtext/TextSVGImage.java
@@ -1,0 +1,58 @@
+
+package blackboard.birt.extensions.rotatedtext;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import org.apache.batik.dom.GenericDOMImplementation;
+import org.apache.batik.svggen.SVGGraphics2D;
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+
+import blackboard.birt.extensions.rotatedtext.SwingGraphicsUtil.LineInfo;
+
+/**
+ * Text drawn on a SVG image.
+ */
+public class TextSVGImage extends TextBufferedImage {
+
+  public TextSVGImage(LineInfo[] theLines, double theAngle, int theWidth, int theHeight, double theTx, double theTy,
+    Color theColor) {
+    super(theLines, theAngle, theWidth, theHeight, theTx, theTy, theColor);
+  }
+  
+  @Override
+  public InputStream getImage() {
+    try {
+      DOMImplementation domImpl =
+        GenericDOMImplementation.getDOMImplementation();
+      
+      // Create an instance of org.w3c.dom.Document.
+      String svgNS = "http://www.w3.org/2000/svg";
+      Document document = domImpl.createDocument(svgNS, "svg", null);
+
+      // Create an instance of the SVG Generator.
+      SVGGraphics2D g2d = new SVGGraphics2D(document);
+      g2d.setSVGCanvasSize(new Dimension(width, height));
+      draw(g2d);
+      
+      // Finally, stream out SVG to the standard output using
+      // UTF-8 encoding.
+      boolean useCSS = true; // we want to use CSS style attributes
+      ByteArrayOutputStream bo = new ByteArrayOutputStream();
+      Writer out = new OutputStreamWriter(bo, "UTF-8");
+      g2d.stream(out, useCSS);
+      return new ByteArrayInputStream(bo.toByteArray());
+    } catch (IOException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+}


### PR DESCRIPTION
It was found that using raster image for rotated text in PDF results in poor quality, especially when zoomed in. This commit provides the possibility to use SVG for better quality.